### PR TITLE
重写断事件检测。和其他小改动

### DIFF
--- a/UmamusumeResponseAnalyzer/Handler/ParseSingleModeCheckEventResponse.cs
+++ b/UmamusumeResponseAnalyzer/Handler/ParseSingleModeCheckEventResponse.cs
@@ -39,8 +39,8 @@ namespace UmamusumeResponseAnalyzer.Handler
 
                     if (i.story_id == 809043003)//佐岳充电
                     {
-                        int suc = i.event_contents_info.choice_array[0].select_index;
-                        int eventType = 0;
+                        var suc = i.event_contents_info.choice_array[0].select_index;
+                        var eventType = 0;
                         if (suc == 1)//加心情
                         {
                             eventType = 2;

--- a/UmamusumeResponseAnalyzer/Handler/Scenarios/Legend.cs
+++ b/UmamusumeResponseAnalyzer/Handler/Scenarios/Legend.cs
@@ -452,21 +452,19 @@ namespace UmamusumeResponseAnalyzer.Handler
 
             if (stage == 5)//选buff阶段
             {
-                AnsiConsole.MarkupLine("选心得: [yellow](注意！顺序和游戏中不同)[/]");
+                AnsiConsole.MarkupLine("选心得:");
                 var obtainableBuffIdArray = @event.data.legend_data_set.obtainable_buff_id_array;
-                foreach (var b in obtainableBuffIdArray)
+                var buffInfoList = obtainableBuffIdArray
+                    .Select(id => GameGlobal.LegendBuffInfo.Find(x => x.buffId == id))
+                    .Where(x => x != null)
+                    .OrderBy(x => x.color)
+                    .ThenBy(x => -x.rank)
+                    .ThenBy(x => x.buffId)
+                    .ToList();
+                foreach (var b in buffInfoList)
                 {
-                    var info = GameGlobal.LegendBuffInfo.Find(x => x.buffId == b);
-                    if (info != null)
-                    {
-                        AnsiConsole.MarkupLine($"{mainColorText(info.color+1)}☆{info.rank} {info.name} - {info.cn_effect}[/]");
-                    }
-                    else
-                    {
-                        AnsiConsole.MarkupLine($"{b}");
-                    }                    
+                    AnsiConsole.MarkupLine($"{mainColorText(b.color+1)}☆{b.rank} {b.name} - {b.cn_effect}[/]");                    
                 }
-
             }
 
             string GaugeColor((int, int) gain) => gain.Item1 switch

--- a/UmamusumeResponseAnalyzer/Server.cs
+++ b/UmamusumeResponseAnalyzer/Server.cs
@@ -105,16 +105,18 @@ namespace UmamusumeResponseAnalyzer
                     {
                         Handlers.ParseTrainingRequest(dyn.ToObject<Gallop.SingleModeExecCommandRequest>());
                     }
-                    if (dyn.choice_number is not null and > (dynamic)0)  // 玩家点击了事件
+                    if (dyn.choice_number is not null)  // 玩家点击了事件
                     {
-                        Handlers.ParseChoiceRequest(dyn.ToObject<Gallop.SingleModeChoiceRequest>());
+                        var req = dyn.ToObject<Gallop.SingleModeChoiceRequest>();
+                        if (req != null && req.choice_number > 0)
+                            Handlers.ParseChoiceRequest(req);
                     }
                     if (dyn.buff_id is not null && GameGlobal.LegendBuffInfo.Count > 0)
                     {
                         var buff = GameGlobal.LegendBuffInfo.Find(x => x.buffId == (int)dyn.buff_id);
                         if (buff != null)
                         {
-                            AnsiConsole.MarkupLine($"[fuchsia]玩家选择: {buff.name}[/]");
+                            AnsiConsole.MarkupLine($"[violet]玩家选择: {buff.name}[/]");
                         }
                     }
                 }


### PR DESCRIPTION
重写断事件检测，现在应该可以检测类似速飞鹰这种，大成功自动断事件的情况
调整传奇杯选buff显示顺序，现在和游戏里一致
恢复显示玩家选择了哪个选项